### PR TITLE
Popup창에 존재하는 코드에 브라우저에서 드래그된 코드를 이어 붙이는 기능 구현

### DIFF
--- a/Codify/background.js
+++ b/Codify/background.js
@@ -1,9 +1,16 @@
 'use strict';
 
 // executed when chrome extension is first installed
-chrome.runtime.onInstalled.addListener(function() {
+chrome.runtime.onInstalled.addListener(function () {
   // initialize storaged code of chrome storage
-  chrome.storage.sync.set({'storagedCode': ""});
+  chrome.storage.sync.set({ 'storagedCode': "" });
+
+  // create 'Overwrite to Codify' contextMenus
+  chrome.contextMenus.create({
+    "id": "overwriteCode",
+    "title": "Overwrite to Codify",
+    "contexts": ["selection"]
+  });
 
   // create 'Append to Codify' contextMenus
   chrome.contextMenus.create({
@@ -13,13 +20,34 @@ chrome.runtime.onInstalled.addListener(function() {
   });
 });
 
-// append selected(dragged) code to popup
-chrome.contextMenus.onClicked.addListener(function(clickData){
-  if (clickData.menuItemId === "appendCode"){
+
+chrome.contextMenus.onClicked.addListener(function (clickData) {
+  // overwrite selected(dragged) code to popup
+  if (clickData.menuItemId === "overwriteCode") {
     chrome.tabs.executeScript(null, {
       code: "window.getSelection().toString();"
-    }, function(selection){
-      chrome.storage.sync.set({'storagedCode': selection});
+    }, function (selection) {
+      chrome.storage.sync.set({ 'storagedCode': selection });
+    });
+  }
+
+  // append selected(dragged) code to popup
+  else if (clickData.menuItemId === "appendCode") {
+    let existingCode, concatCode;
+    chrome.tabs.executeScript(null, {
+      code: "window.getSelection().toString();"
+    }, function (selection) {
+      chrome.storage.sync.get('storagedCode', function (item) {
+        existingCode = item.storagedCode;
+        if (existingCode.toString().localeCompare("") != 0) {
+          concatCode = existingCode + '\n' + selection;
+          //concatCode = existingCode.concat('\n', selection);
+        }
+        else {
+          concatCode = selection;
+        }
+        chrome.storage.sync.set({ 'storagedCode': concatCode });
+      });
     });
   }
 });


### PR DESCRIPTION
기존 contextMenus 중 'Append to Codify'는 Popup창에 존재하는 코드 뒤에 브라우저에서 드래그된 코드를 이어 붙이는 기능을 하도록 수정되었으며
새롭게 만들어진 contextMenus인 'Overwrite to Codify'는 Popup창에 존재하는 코드 위에 브라우저에서 드래그된 코드를 덮어 쓰는 기능을 하도록 구현하였습니다.

코드 영역 선택(드래그)>우클릭>'Append to Codify' OR 'Overwrite to Codify' 방식을 유지할거면 그대로 사용하면 될 것 같고
소스 코드 인식 영역 위에 버튼을 추가하는 방식을 사용할거면 background.js에 chrome.contextMenus.onClicked.addListener 함수 내용만 가져다 쓰면 될 것 같습니다.