### PR TITLE
Editor 코드 수정 후 팝업을 닫을 시 수정 내역이 저장되지 않는 버그 수정

### DIFF
--- a/Codify/js/codify/popup.js
+++ b/Codify/js/codify/popup.js
@@ -42,6 +42,10 @@ load2Textarea(codeTextArea, 'storagedCode', function () {
         theme: "blackboard",
         mode: "text/x-c++src",
         value: codeTextArea.value
+    }).on('change', editor => {
+        saveStorage({
+            storagedCode: editor.getValue()
+        });
     });
 });
 


### PR DESCRIPTION
Editor 코드 수정 후 팝업을 닫을 시 수정 내역이 저장되지 않는 버그를 
내용이 수정될 때 마다 코드를 저장하도록 하여 해결하였습니다.