### PR TITLE
Add Random Secret Key Generator. Close #70

### DIFF
--- a/api-server/server/server/settings.py
+++ b/api-server/server/server/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+import string, random
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +21,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '#du1fyyi8$jl%@#gzjqeun=1qom7+&0d*%-ly17bwnfd=*hvsi'
+# Get ascii Characters numbers and punctuation (minus quote characters as they could terminate string).
+
+_secret_key_string = ''.join([string.ascii_letters, string.digits, string.punctuation]).replace('\'', '').replace('"', '').replace('\\', '')
+
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/api-server/server/server/settings.py
+++ b/api-server/server/server/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'api',
 ]
 
-MIDDLEWARE 
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',

--- a/api-server/server/server/settings.py
+++ b/api-server/server/server/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Get ascii Characters numbers and punctuation (minus quote characters as they could terminate string).
 
 _secret_key_string = ''.join([string.ascii_letters, string.digits, string.punctuation]).replace('\'', '').replace('"', '').replace('\\', '')
-
+SECRET_KEY = ''.join([random.SystemRandom().choice(_secret_key_string) for i in range(50)])
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'api',
 ]
 
-MIDDLEWARE = [
+MIDDLEWARE 
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',


### PR DESCRIPTION
Secret Key Random Generator Added.
비밀키는 따로 보관해도 좋지만, 필요할 때 Django에서 내부적 호출로 불러올 수 있으니 서버 reboot시마다 50자리의 랜덤한 문자열로 생성하게 해두면 Key를 파일로 따로 관리하지 않아도 좋을 것 같다고 판단했습니다.

setting.py의 새로운 import가 추가되었습니다. import string과 import random 입니다. Dependency 관리에 참고해주시기 바랍니다.

Close #70